### PR TITLE
Add example for MC spark log4j2 usage.

### DIFF
--- a/spark-2.x/pom.xml
+++ b/spark-2.x/pom.xml
@@ -163,6 +163,15 @@
             <artifactId>spark-interpreter</artifactId>
             <version>0.8.1</version>
         </dependency>
+
+        <!--For usage of log4j2 interface-->
+        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.12.1</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -205,7 +214,9 @@
                                 </transformer>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.apache.spark.sql.sources.DataSourceRegister</resource>
+                                    <resource>
+                                        META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+                                    </resource>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/spark-2.x/src/main/java/com/aliyun/odps/spark/examples/utils/ConfigLog4j2.java
+++ b/spark-2.x/src/main/java/com/aliyun/odps/spark/examples/utils/ConfigLog4j2.java
@@ -1,0 +1,56 @@
+package com.aliyun.odps.spark.examples.utils;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.AppenderRef;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+public class ConfigLog4j2 {
+
+  private static final LoggerContext CONTEXT;
+  public static final String DEFAULT_APPENDER = "MY_STDOUT";
+  public static final String
+      DEFAULT_PATTERN =
+      "%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger - %msg %ex %n";
+
+  static {
+    CONTEXT = (LoggerContext) LogManager.getContext(false);
+  }
+
+  /**
+   * @Description: add specific logger for specific package
+   * @Param: packageName, such as com.xx.yy
+   * @return: void
+   * @Author: lcj265802@alibaba-inc.com
+   * @Date: 2020/12/29
+   */
+  public static void initPackageLogger(String packageName) {
+    LoggerContext loggerContext = CONTEXT;
+    Configuration config = loggerContext.getConfiguration();
+
+    ConsoleAppender.Builder builder = ConsoleAppender.newBuilder();
+    builder.setName(DEFAULT_APPENDER);
+    builder.setLayout(PatternLayout.newBuilder().withPattern(DEFAULT_PATTERN).build());
+    Appender stdoutAppender = builder.setTarget(ConsoleAppender.Target.SYSTEM_OUT).build();
+    stdoutAppender.start();
+
+    config.addAppender(stdoutAppender);
+
+    AppenderRef ref = AppenderRef.createAppenderRef(DEFAULT_APPENDER, null, null);
+    AppenderRef[] refs = new AppenderRef[]{ref};
+
+    LoggerConfig
+        loggerConfig =
+        LoggerConfig.createLogger(false, Level.INFO, packageName,
+                                  "true", refs, null, config, null);
+    loggerConfig.addAppender(stdoutAppender, null, null);
+    config.addLogger(packageName, loggerConfig);
+
+    loggerContext.updateLoggers();
+  }
+}

--- a/spark-2.x/src/main/scala/com/aliyun/odps/spark/examples/log4j2/Logger.scala
+++ b/spark-2.x/src/main/scala/com/aliyun/odps/spark/examples/log4j2/Logger.scala
@@ -1,0 +1,9 @@
+package com.aliyun.odps.spark.examples.log4j2
+
+import org.apache.logging.log4j
+import org.apache.logging.log4j.LogManager
+
+trait Logger {
+  val log: log4j.Logger = LogManager.getLogger(this.getClass)
+  log
+}

--- a/spark-2.x/src/main/scala/com/aliyun/odps/spark/examples/log4j2/SimpleWordCount.scala
+++ b/spark-2.x/src/main/scala/com/aliyun/odps/spark/examples/log4j2/SimpleWordCount.scala
@@ -1,0 +1,26 @@
+package com.aliyun.odps.spark.examples.log4j2
+
+import com.aliyun.odps.spark.examples.utils.ConfigLog4j2
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+
+object SimpleWordCount extends Logger {
+  def main(args: Array[String]): Unit = {
+
+    ConfigLog4j2.initPackageLogger("com.aliyun.odps.spark.examples.log4j2")
+    val spark: SparkSession = SparkSession
+      .builder()
+      .appName("WordCount")
+      .getOrCreate()
+
+    log.info("My Test!")
+    val wordList = List("Hello", "World", "Hello")
+    val rdd: RDD[String] = spark.sparkContext.parallelize(Seq(wordList: _*)).cache()
+    val resultRDD: RDD[(String, Int)] = rdd.map(w => (w, 1)).reduceByKey(_ + _)
+    resultRDD.collect().foreach(v => {
+      log.info(s"${v._1} has num ${v._2}")
+    })
+
+    spark.stop()
+  }
+}


### PR DESCRIPTION
A new example that lets users themselves use Log4J2 interface in MaxCompute Spark has been added.